### PR TITLE
fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 description = "Python package for 'CheckEmbed'"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.8.12"
 classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
@@ -29,7 +29,6 @@ dependencies = [
   "bert-score>=0.3.13,<1.0.0",
   "transformers>=4.41.0,<5.0.0",
   "accelerate>=0.30.1,<1.0.0",
-  "pandas>=2.2.2,<3.0.0",
   "seaborn>=0.13.2,<1.0.0"
 ]
 


### PR DESCRIPTION
Pandas 2.2.2 is not compatible with python 3.8.
Removed not used pandas 2.2.2.

Changed constraint to python 3.8.12, tested working version.